### PR TITLE
Migrate from JCenter to JitPack

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      NDK_VERSION: 21.0.6113669
+      NDK_VERSION: 21.1.6352462
 
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -18,16 +18,20 @@ To keep network log history the web system uses the built-in IndexedDB from the 
 https://github.com/pakerwreah/InspectorWeb
 
 ## Android
-[![Version](https://api.bintray.com/packages/pakerwreah/Inspector/br.newm.inspector/images/download.svg)](https://bintray.com/pakerwreah/Inspector/br.newm.inspector/_latestVersion)
+[![Version](https://jitpack.io/v/pakerwreah/Inspector.svg)](https://jitpack.io/#pakerwreah/Inspector)
+
+<details>
+    <summary>Setup</summary>
+
 #### Gradle
 ```gradle
 repositories {
-    jcenter()
+    maven { url "https://jitpack.io" }
 }
 ```
 ```gradle
 dependencies {
-    implementation "br.newm.inspector:inspector:<version>"
+    implementation "com.github.pakerwreah:Inspector:<release-tag>"
 }
 ```
 
@@ -35,6 +39,10 @@ dependencies {
 ```
 -keep class br.newm.inspector.* { *; }
 ```
+</details>
+
+<details>
+    <summary>Usage</summary>
 
 #### Application
 ```java
@@ -128,15 +136,24 @@ Inspector.sendMessage("mykey", "Hello world!");
 adb forward tcp:30000 tcp:30000
 ```
 Or configure its network as bridge and use the device's IP
+</details>
 
 ## iOS
 [![Version](https://img.shields.io/cocoapods/v/IOSInspector.svg)](https://cocoapods.org/pods/IOSInspector)
+
+<details>
+    <summary>Setup</summary>
+
 #### CocoaPods
 ```gradle
 target 'MyApp' do
    pod "IOSInspector"
 end
 ```
+</details>
+
+<details>
+    <summary>Usage</summary>
 
 #### AppDelegate
 ```swift
@@ -227,3 +244,4 @@ new WebSocket(`ws://${location.hostname}:${location.port}/plugins/ws/mykey`)
 ```swift
 IOSInspector.sendMessage(to: "mykey", message: "Hello world!")
 ```
+</details>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Inspector
-![release](https://img.shields.io/github/v/release/pakerwreah/Inspector)
+[![release](https://img.shields.io/github/v/release/pakerwreah/Inspector)](https://github.com/pakerwreah/Inspector/releases/latest)
 ![c++](https://img.shields.io/badge/C++-17-blue.svg?style=flat&logo=c%2B%2B)
 ![android](https://img.shields.io/badge/Android-grey.svg?style=flat&logo=android)
 ![ios](https://img.shields.io/badge/iOS-grey.svg?style=flat&logo=apple)

--- a/android/app/app/build.gradle
+++ b/android/app/app/build.gradle
@@ -32,7 +32,8 @@ dependencies {
     localImplementation project(':inspector')
     localImplementation 'com.squareup.okhttp3:okhttp:4.4.0'
 
-    mavenImplementation 'com.github.pakerwreah:Inspector:jitpack-SNAPSHOT'
+    // gradle resolves all flavors every time, so we have to comment this out
+    // mavenImplementation 'com.github.pakerwreah:Inspector:develop-SNAPSHOT'
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/android/app/app/build.gradle
+++ b/android/app/app/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     localImplementation project(':inspector')
     localImplementation 'com.squareup.okhttp3:okhttp:4.4.0'
 
-    mavenImplementation 'br.newm.inspector:inspector:1.5.1'
+    mavenImplementation 'com.github.pakerwreah:Inspector:jitpack-SNAPSHOT'
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,19 +4,18 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
-        jcenter()
-
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
+        classpath 'com.android.tools.build:gradle:4.2.1'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/android/app/gradle/wrapper/gradle-wrapper.properties
+++ b/android/app/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -3,19 +3,18 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
+        classpath 'com.android.tools.build:gradle:4.2.1'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/android/lib/deploy.sh
+++ b/android/lib/deploy.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-./gradlew clean
-./gradlew assembleRelease
-./gradlew bintrayUpload

--- a/android/lib/gradle/wrapper/gradle-wrapper.properties
+++ b/android/lib/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 16 20:47:40 BRT 2020
+#Mon May 17 20:09:34 BRT 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/android/lib/inspector/build.gradle
+++ b/android/lib/inspector/build.gradle
@@ -17,7 +17,7 @@ android {
     externalNativeBuild {
         cmake {
             path "src/main/cpp/CMakeLists.txt"
-            version "3.18.1"
+            version "3.10.2"
         }
     }
 }

--- a/android/lib/inspector/build.gradle
+++ b/android/lib/inspector/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 30
-    ndkVersion '21.0.6113669'
+    ndkVersion '21.1.6352462'
     buildToolsVersion "30.0.2"
     defaultConfig {
         minSdkVersion 14
@@ -17,7 +17,7 @@ android {
     externalNativeBuild {
         cmake {
             path "src/main/cpp/CMakeLists.txt"
-            version "3.10.2"
+            version "3.18.1"
         }
     }
 }

--- a/android/lib/inspector/publish.gradle
+++ b/android/lib/inspector/publish.gradle
@@ -1,22 +1,11 @@
-apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
-version '1.5.1'
+version '1.5.2'
 group 'br.newm.inspector'
-
-def getProperties(filename) {
-    try {
-        Properties properties = new Properties()
-        properties.load(project.rootProject.file(filename).newDataInputStream())
-        return properties
-    } catch (Exception ex) {
-        logger.log(LogLevel.ERROR, ex.message)
-    }
-}
 
 publishing {
     publications {
-        Production(MavenPublication) {
+        release(MavenPublication) {
             artifact("$buildDir/outputs/aar/inspector-release.aar")
             groupId this.group
             artifactId 'inspector'
@@ -33,37 +22,6 @@ publishing {
                     dependencyNode.appendNode('version', it.version)
                 }
             }
-        }
-    }
-}
-
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-artifacts {
-    archives sourcesJar
-}
-
-bintray {
-    def props = getProperties('bintray.properties')
-    if (props) {
-        user = props.getProperty("user")
-        key = props.getProperty("key")
-    }
-    publications = ['Production']
-    configurations = ['archives']
-    dryRun = false
-    publish = true
-    override = true
-    pkg {
-        repo = 'Inspector'
-        name = this.group
-        version {
-            name = this.version
-            vcsTag = "v${this.version}"
-            released  = new Date()
         }
     }
 }

--- a/android/lib/inspector/src/main/cpp/CMakeLists.txt
+++ b/android/lib/inspector/src/main/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13.0)
+cmake_minimum_required(VERSION 3.10.2)
 project(Inspector)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/android/lib/inspector/src/main/cpp/CMakeLists.txt
+++ b/android/lib/inspector/src/main/cpp/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.13.0)
+project(Inspector)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.13.0)
+project(Inspector)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -6,8 +7,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(CMAKE_C_COMPILER clang)
 set(CMAKE_CXX_COMPILER clang++)
-
-project(inspector)
 
 add_custom_target(cpplint python3 tools/cpplint/cpplint.py --quiet --recursive src WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+before_install:
+  - cd android/lib

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,4 @@
 before_install:
   - cd android/lib
+install:
+  - ./gradlew assembleRelease publishToMavenLocal


### PR DESCRIPTION
JCenter has been discontinued, so we have to migrate to somewhere else to be able to upload new versions.